### PR TITLE
gpio_claim module: Improve logging and refactoring

### DIFF
--- a/kernel/gpio/gpio.c
+++ b/kernel/gpio/gpio.c
@@ -19,23 +19,24 @@ module_param(debug, int, 0644);
 MODULE_PARM_DESC(debug, "Enable debugging output: 0=off, 1=on");
 
 #define DEBUG_PRINTK(fmt, ...) do { if (debug) printk(fmt, ##__VA_ARGS__); } while (0)
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 
 int claim_gpio(int gpio) {
-    DEBUG_PRINTK("gpio_claim: GPIO[%i] Requesting...\n", gpio);
+    dynamic_pr_debug("gpio_claim: GPIO[%i] Requesting...\n", gpio);
 
     if (!gpio_is_valid(gpio)) {
-        DEBUG_PRINTK("gpio_claim: GPIO[%i] is not valid.\n", gpio);
+        dynamic_pr_debug("gpio_claim: GPIO[%i] is not valid.\n", gpio);
         return -1;
     }
 
     if (gpio_request(gpio, "gpio_claimer") < 0) {
-        DEBUG_PRINTK("gpio_claim: Failed to request GPIO[%i]. It might be already in use or there's a conflict.\n", gpio);
+        dynamic_pr_debug("gpio_claim: Failed to request GPIO[%i]. It might be already in use or there's a conflict.\n", gpio);
         return -1;
     }
 
-    DEBUG_PRINTK("gpio_claim: GPIO[%i] Setting direction...\n", gpio);
+    dynamic_pr_debug("gpio_claim: GPIO[%i] Setting direction...\n", gpio);
     gpio_direction_output(gpio, 0);
-    DEBUG_PRINTK("gpio_claim: GPIO[%i] Exporting...\n", gpio);
+    dynamic_pr_debug("gpio_claim: GPIO[%i] Exporting...\n", gpio);
     gpio_export(gpio, true);
 
     return 0;
@@ -72,12 +73,12 @@ static const struct file_operations claim_proc_fops = {
 static __init int init_claim(void) {
     claim_proc_dir = proc_mkdir(PROC_DIR, NULL);
     if (!claim_proc_dir) {
-        DEBUG_PRINTK("gpio_claim: err: proc_mkdir failed\n");
+        dynamic_pr_debug("gpio_claim: err: proc_mkdir failed\n");
         return -ENOMEM;
     }
 
     if (!proc_create(PROC_ENTRY, 0644, claim_proc_dir, &claim_proc_fops)) {
-        DEBUG_PRINTK("gpio_claim: err: proc_create failed\n");
+        dynamic_pr_debug("gpio_claim: err: proc_create failed\n");
         proc_remove(claim_proc_dir);
         return -ENOMEM;
     }


### PR DESCRIPTION
Fix the debugging messages to indicate to the user which GPIO's are causing errors.  This change will aid in debugging and providing support to users of OpenIPC.  

Tested on: Ingenic T31

before: 
```
[    7.177557] Ingenic GPIO claim module (c) OpenIPC.org
[    7.199318] gpio:jz->reg = 0xb0011000
[    7.199330] gpio pin: 0x100000
[    7.199336] jz->dev_map[0]: 0x89f86f00
[    7.199346] CPU: 0 PID: 681 Comm: load_ingenic Tainted: G           O 3.10.14__isvp_swan_1.0__ #12
[    5.854578] "echo 1 > enable" or "echo 0 > enable " 
[    7.199354] Stack : 00000000 00000000 00000000 00000000 8058316a 00000056 30001c01 80580000
[    7.199359] 	  8049e04c 81146a58 80508bc7 80582904 000002a9 8050c46c 00000063 00000030
[    7.199359] 	  770369ec 803efd9c 00000000 800371fc 00000002 8290301f 8049f9bc 81775dc4
[    7.199359] 	  00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[    7.199359] 	  00000000 00000000 00000000 00000000 00000000 00000000 00000000 81775d50
[    7.199359] 	  ...
[    7.199433] Call Trace:
[    7.199447] [<8001fdf4>] show_stack+0x58/0x70
[    7.199460] [<80018298>] jz_gpio_request+0xd8/0x13c
[    7.199470] [<801d04e8>] gpiod_request+0x1d0/0x220
[    7.199482] [<c0780058>] claim_gpio+0x58/0xbc [gpio]
[    7.199492] [<c0780160>] claim_proc_write+0xa4/0xe4 [gpio]
[    7.199503] [<80125388>] proc_reg_write+0x80/0x94
[    7.199514] [<800d2784>] vfs_write+0xd8/0x198
[    7.199522] [<800d2dec>] SyS_write+0x60/0xa4
[    7.199532] [<80022adc>] stack_done+0x20/0x44
[    7.199538] 
[    7.199542] arch/mips/xburst/soc-t31/common/gpio.c:gpio functions has redefinitiongpio:jz->reg = 0xb0011000
[    7.216788] gpio pin: 0x200000
[    7.216796] jz->dev_map[0]: 0x89f86f00
[    7.216807] CPU: 0 PID: 681 Comm: load_ingenic Tainted: G           O 3.10.14__isvp_swan_1.0__ #12
[    7.216813] Stack : 00000000 00000000 00000000 00000000 8058316a 00000056 30001c01 80580000
[    7.216813] 	  8049e04c 81146a58 80508bc7 80582904 000002a9 8050c46c 00000063 00000030
[    7.216813] 	  770369ec 803efd9c 00000000 800371fc 00000002 8290301f 8049f9bc 81775dc4
[    7.216813] 	  00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[    7.216813] 	  00000000 00000000 00000000 00000000 00000000 00000000 00000000 81775d50
[    7.216813] 	  ...
[    7.216890] Call Trace:
[    7.216904] [<8001fdf4>] show_stack+0x58/0x70
[    7.216916] [<80018298>] jz_gpio_request+0xd8/0x13c
[    7.216928] [<801d04e8>] gpiod_request+0x1d0/0x220
[    7.216940] [<c0780058>] claim_gpio+0x58/0xbc [gpio]
[    7.216950] [<c0780160>] claim_proc_write+0xa4/0xe4 [gpio]
[    7.216960] [<80125388>] proc_reg_write+0x80/0x94
[    7.216970] [<800d2784>] vfs_write+0xd8/0x198
[    7.216980] [<800d2dec>] SyS_write+0x60/0xa4
[    7.216990] [<80022adc>] stack_done+0x20/0x44
[    7.216995] 
[    7.217000] arch/mips/xburst/soc-t31/common/gpio.c:gpio functions has redefinition
```
after (with fixes from https://github.com/OpenIPC/linux/pull/10)
```
[    7.428959] Ingenic GPIO claim module (c) OpenIPC.org
[    7.450528] GPIO[52] Requesting...
[    7.450544] GPIO[52] Setting direction...
[    7.450552] GPIO[52] Exporting...
[    7.450846] GPIO[52] Claiming...
[    7.466737] GPIO[53] Requesting...
[    7.466753] GPIO[53] Setting direction...
[    7.466760] GPIO[53] Exporting...
[    7.467064] GPIO[53] Claiming...
```