### PR TITLE
pwm-hal: don't stop driver initialization is tcu channel claim fails

### DIFF
--- a/kernel/misc/sample_pwm/pwm_hal.c
+++ b/kernel/misc/sample_pwm/pwm_hal.c
@@ -353,7 +353,7 @@ static int jz_pwm_probe(struct platform_device *pdev)
 		gpwm->pwm_device_t[i]->pwm_device = devm_pwm_get(&pdev->dev, pd_name);
 		if (IS_ERR(gpwm->pwm_device_t[i]->pwm_device)) {
 			dev_err(&pdev->dev, "devm_pwm_get error !");
-			return -ENOMEM;
+			continue;  // Skip to next iteration, dont stop
 		}
 
 		gpwm->pwm_device_t[i]->duty = -1;


### PR DESCRIPTION
pwm-hal: don't stop driver initialization is tcu channel claim fails

If a tcu channel is currently claimed by another driver, for example, `sample_motor` on PTZ devices, the driver stops initializing and never brings up /dev/pwm.  

Lets fix the driver to continue, even if a channel is already claimed by another driver.  This way, we can continue the PWM driver loading and use PWM associated with other channels.

This fixes motor + pwm on the ingenic platform with openipc.